### PR TITLE
[BOP-56] Add CI when merging to main

### DIFF
--- a/.github/workflows/Merge.yml
+++ b/.github/workflows/Merge.yml
@@ -1,0 +1,19 @@
+name: Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  vet:
+    uses: ./.github/workflows/vet.yml
+  unit-test:
+      uses: ./.github/workflows/unit.yml
+  build:
+    uses: ./.github/workflows/build.yml
+  # This was tested to be working but is not used because ghcr.io is currently our public release registry
+  # push-to-ghcr:
+  #   if: ${{ always() && contains(join(needs.*.result, ','), 'success') }} # if all need jobs are successful
+  #   needs: [vet, unit-test, build]
+  #   uses: ./.github/workflows/push-to-ghcr.yml

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,3 +9,7 @@ These are the high level workflows that can be associated with what triggers the
 ## Jobs
 
 These are the smaller individual tasks that are used to build up the larger parent workflows. They can be thought of as running unit tests, building the binaries, or linting the code. When you open one of the parent caller actions in the actions tab, they will show these individual jobs. Convention has become to lowercase the first letter of these workflow's name.
+
+# Working with workflows
+
+The easiest way to test a workflow is by creating it on your forked repo. This way you have control over the settings and you can manipulate branches anyway you need to trigger the workflow. When testing this way, you should be careful that you are pushing to your repo and not the company's and also make sure to clean everything up in your repo once you have finished testing.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,16 @@ jobs:
       - name: Build docker image
         working-directory: .
         run: make docker-build
+
+      - name: Save docker image
+        if: ${{ github.event_name == 'release' || github.event_name == 'push'}} # release or push to main
+        working-directory: .
+        run: docker save ghcr.io/mirantis/boundless-operator:latest -o /tmp/boundless-operator.tar
+
+      - name: Upload docker image
+        if: ${{ github.event_name == 'release' || github.event_name == 'push'}} # release or push to main
+        uses: actions/upload-artifact@v3
+        with:
+          name: boundless-operator
+          retention-days: 1
+          path: /tmp/boundless-operator.tar

--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -1,11 +1,10 @@
-name: Build and Push Docker Image
+name: Push docker image to ghcr.io
 
 on:
-  push:
-    branches: [ "main" ]
+  workflow_call:
 
 jobs:
-  build-and-push:
+  push:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -18,9 +17,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build docker image
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: boundless-operator
+          path: /tmp
+
+      - name: Load docker image
         working-directory: .
-        run: make docker-build
+        run: docker load --input /tmp/boundless-operator.tar
 
       - name: Push docker image to ghcr.io
         working-directory: .

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,26 @@
+# CI
+
+This document describes the CI/CD pipeline for the project. This document is for those developing on the project to understand everything that is running when they make a change to the code. If you are interested in modifying the CI/CD pipeline, see [README](.github/workflows/README.md) in the workflows directory.
+
+## PRs
+
+CI for a PR will trigger whenever a PR is opened, reopened, or pushed. The jobs ran on a PR are meant to be lightweight enough that we can repeatedly run them (each push) but cover enough of the code that we don't have to create a followup PR to fix things that we've missed. The jobs ran on a PR are:
+
+- 'vet' - Check the code changes and make sure they adhere to the standard Golang style guide
+- 'test' - Run the unit tests on the code changes
+- 'build' - Build an image containing the code changes
+
+## Merging to main
+
+Merging to main runs many of the same tests as a PR to verify that merging the code didn't introduce any new issues. Merging will also run integration tests to verify that the code works with the rest of the system as these tests require more setup and take longer to run.
+
+TODO: code coverage
+TODO: If you merge a change into main and an issue is found, you will be notified on slack that you have broken main and need to fix it.
+
+## Releases
+
+A release is triggered when a pre-release is created in the github repo. This will run EVERYTHING from scratch. Starting from zero may take more time but this ensures that nothing slips by us before sending out the release. This includes any static code analysis, unit tests, integration tests, and building the binaries. If everything passes, the artifacts will uploaded to the release and the release will be ready for review before it is manually published.
+
+## Nightlys (TBD)
+
+Nightlys are triggered every night at 12:00 AM UTC. This will run EVERYTHING from scratch. This includes any static code analysis, unit tests, integration tests, and building the binaries.


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-56

## What this PR does
Adds a CI to run when we merge a PR into main

The step to push the image to ghcr.io is commented out because this is currently our public registry and pushing changes every time we commit to main is causing breaking changes before we want them to go out.

The images created from this are available in the action's page. We can't use this using a pull command but it is a temporary way to get the image if we want it. We'll have to determine where we want to store internal/dev images vs external/release images to clean this up.

## Testing
I tested this on my fork of the repo. The push stage didn't work due to credentials but this step was previously working and so I wasn't worried about it. 