### PR TITLE
Install ingress component only when a provider is specified

### DIFF
--- a/controllers/blueprint_controller.go
+++ b/controllers/blueprint_controller.go
@@ -62,7 +62,7 @@ func (r *BlueprintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	if instance.Spec.Components.Core != nil && instance.Spec.Components.Core.Ingress != nil {
+	if instance.Spec.Components.Core != nil && instance.Spec.Components.Core.Ingress != nil && instance.Spec.Components.Core.Ingress.Provider != "" {
 		logger.Info("Reconciling ingress")
 		err = r.createOrUpdateIngress(ctx, logger, ingressResource(instance.Spec.Components.Core.Ingress))
 		if err != nil {


### PR DESCRIPTION
The issue is that `bctl` is providing an empty `spec.components.core` and `spec.components.core.ingress` object when no core components defined in the blueprint (fix will this in `bctl`).

