### PR TITLE
[BOP-138] fix for infinite reconciliation in boundless-cli for manifests

### DIFF
--- a/controllers/manifest_controller.go
+++ b/controllers/manifest_controller.go
@@ -131,7 +131,7 @@ func (r *ManifestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
-	if (existing.Spec.Checksum != existing.Spec.NewChecksum) && (existing.Spec.NewChecksum != "") && (existing.Status.Type != boundlessv1alpha1.TypeComponentAvailable) {
+	if (existing.Spec.Checksum != existing.Spec.NewChecksum) && (existing.Spec.NewChecksum != "") {
 		// Update is required
 		logger.Info("checksum differs, update needed", "Checksum", existing.Spec.Checksum, "NewChecksum", existing.Spec.NewChecksum)
 		// First, update the checksum to avoid any reconciliation


### PR DESCRIPTION
JIRA ticket: https://mirantis.jira.com/browse/BOP-138

While testing manifest update support on CLI, I observed that there is an infinite reconciliation in manifest controller.
On investigation, it was found that there was a bug introduced in https://github.com/Mirantis/boundless-operator/commit/8d3325b89228520dad78d1cb13784613c067a6f9#diff-fbe717a7e91e647466b5a80e190e07325d14895539509d250f58f44100542923R133.

This PR fixes the bug.


Please see : I had to remove the condition altogether in order to get update working. For some reason, boundlessv1alpha1.TypeComponentAvailable status is not set. I don't see this trace. https://github.com/Mirantis/boundless-operator/blob/main/controllers/manifest_controller.go#L213 and this needs further investigation. To get the things working for now, this is the best solution.