### PR TITLE
[BOP-81] Operator - Validate Blueprint CRD

### DIFF
--- a/api/v1alpha1/addon_types.go
+++ b/api/v1alpha1/addon_types.go
@@ -13,8 +13,12 @@ type AddonSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	Name      string        `json:"name"`
-	Kind      string        `json:"kind"`
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+
+	// +kubebuilder:validation:Enum=manifest;chart;Manifest;Chart
+	Kind string `json:"kind"`
+
 	Enabled   bool          `json:"enabled"`
 	Namespace string        `json:"namespace,omitempty"`
 	Chart     *ChartInfo    `json:"chart,omitempty"`
@@ -22,14 +26,21 @@ type AddonSpec struct {
 }
 
 type ChartInfo struct {
-	Name    string                        `json:"name"`
-	Repo    string                        `json:"repo"`
-	Version string                        `json:"version"`
-	Set     map[string]intstr.IntOrString `json:"set,omitempty"`
-	Values  string                        `json:"values,omitempty"`
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+
+	// +kubebuilder:validation:Required
+	Repo string `json:"repo"`
+
+	// +kubebuilder:validation:Required
+	Version string `json:"version"`
+
+	Set    map[string]intstr.IntOrString `json:"set,omitempty"`
+	Values string                        `json:"values,omitempty"`
 }
 
 type ManifestInfo struct {
+	// +kubebuilder:validation:MinLength:=1
 	URL string `json:"url"`
 }
 

--- a/api/v1alpha1/ingress_types.go
+++ b/api/v1alpha1/ingress_types.go
@@ -13,9 +13,13 @@ type IngressSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Enabled is a flag to enable/disable the ingress
-	Enabled  bool   `json:"enabled"`
+	// +kubebuilder:validation:Required
+	Enabled bool `json:"enabled"`
+
+	// +kubebuilder:validation:Required
 	Provider string `json:"provider"`
-	Config   string `json:"config,omitempty"`
+
+	Config string `json:"config,omitempty"`
 }
 
 // IngressStatus defines the observed state of Ingress

--- a/api/v1alpha1/manifest_types.go
+++ b/api/v1alpha1/manifest_types.go
@@ -11,8 +11,8 @@ import (
 type ManifestSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	Url string `json:"url"`
 
-	Url         string           `json:"url"`
 	NewChecksum string           `json:"newChecksum,omitempty"`
 	Checksum    string           `json:"checksum"`
 	Objects     []ManifestObject `json:"objects,omitempty"`

--- a/config/crd/bases/boundless.mirantis.com_addons.yaml
+++ b/config/crd/bases/boundless.mirantis.com_addons.yaml
@@ -65,10 +65,16 @@ spec:
               enabled:
                 type: boolean
               kind:
+                enum:
+                - manifest
+                - chart
+                - Manifest
+                - Chart
                 type: string
               manifest:
                 properties:
                   url:
+                    minLength: 1
                     type: string
                 required:
                 - url

--- a/config/crd/bases/boundless.mirantis.com_blueprints.yaml
+++ b/config/crd/bases/boundless.mirantis.com_blueprints.yaml
@@ -68,10 +68,16 @@ spec:
                         enabled:
                           type: boolean
                         kind:
+                          enum:
+                          - manifest
+                          - chart
+                          - Manifest
+                          - Chart
                           type: string
                         manifest:
                           properties:
                             url:
+                              minLength: 1
                               type: string
                           required:
                           - url

--- a/config/crd/bases/boundless.mirantis.com_manifests.yaml
+++ b/config/crd/bases/boundless.mirantis.com_manifests.yaml
@@ -62,6 +62,8 @@ spec:
                   type: object
                 type: array
               url:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file'
                 type: string
             required:
             - checksum

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/mirantis/boundless-operator
-  newTag: manifest
+  newTag: validate

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: ghcr.io/mirantis/boundless-operator:latest
+        image: ghcr.io/mirantis/boundless-operator:0.2.0
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/deploy/static/boundless-operator.yaml
+++ b/deploy/static/boundless-operator.yaml
@@ -73,10 +73,16 @@ spec:
               enabled:
                 type: boolean
               kind:
+                enum:
+                - manifest
+                - chart
+                - Manifest
+                - Chart
                 type: string
               manifest:
                 properties:
                   url:
+                    minLength: 1
                     type: string
                 required:
                 - url
@@ -180,10 +186,16 @@ spec:
                         enabled:
                           type: boolean
                         kind:
+                          enum:
+                          - manifest
+                          - chart
+                          - Manifest
+                          - Chart
                           type: string
                         manifest:
                           properties:
                             url:
+                              minLength: 1
                               type: string
                           required:
                           - url
@@ -341,6 +353,7 @@ spec:
                   type: object
                 type: array
               url:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
                 type: string
             required:
             - checksum


### PR DESCRIPTION
JIRA Ticket : https://mirantis.jira.com/browse/BOP-81

This PR adds validations for BOP crds using kubebuilder markers(https://book.kubebuilder.io/reference/markers/crd-validation). Since there wasn't any explicit criteria, I looked at all the elements in the code that are required for Boundless Operator blueprint and added possible validations around it. 

Here is the summary of the validations added and the way they have been tested.

1) Addons must be of kind: manifest, Manifest, chart, Chart 

```
addons:
      - name: example-server
        kind: unknown
        enabled: true
        namespace: default
        chart:
          name: nginx
          repo: https://charts.bitnami.com/bitnami
          version: 15.1.1
          values: |
            "service":
              "type": "ClusterIP"
```

kubectl apply -f blueprint_manifest.yaml
`The Blueprint "my-cluster" is invalid: spec.components.addons[0].kind: Unsupported value: "unknown": supported values: "manifest", "chart", "Manifest", "Chart"`


2) Addon name is essential

```
addons:
      #- name: example-server
      - kind: unknown
        enabled: true
        namespace: default
        chart:
          name: nginx
          repo: https://charts.bitnami.com/bitnami
          version: 15.1.1
          values: |
            "service":
              "type": "ClusterIP"
```

kubectl apply -f blueprint_manifest.yaml
error: error validating "blueprint_manifest.yaml": error validating data: ValidationError(Blueprint.spec.components.addons[0]): missing required field "name" in com.mirantis.boundless.v1alpha1.Blueprint.spec.components.addons; if you choose to ignore these errors, turn validation off with --validate=false

3) Provider name essential for Core component Ingress

spec:
  components:
    core:
      ingress:
        enabled: true
        #provider: ingress-nginx
        config: |
          controller:
            service:
              nodePorts:
                http: 30000
                https: 30001
              type: NodePort

kubectl apply -f blueprint_manifest.yaml
`error: error validating "blueprint_manifest.yaml": error validating data: ValidationError(Blueprint.spec.components.core.ingress): missing required field "provider" in com.mirantis.boundless.v1alpha1.Blueprint.spec.components.core.ingress; if you choose to ignore these errors, turn validation off with --validate=false`

4) Enabled flag essential for Core component Ingress and should only allow boolean true or false

```
spec:
  components:
    core:
      ingress:
        #enabled: true
        provider: ingress-nginx
        config: |
          controller:
            service:
              nodePorts:
                http: 30000
                https: 30001
              type: NodePort
```


kubectl apply -f blueprint_manifest.yaml
error: error validating "blueprint_manifest.yaml": error validating data: ValidationError(Blueprint.spec.components.core.ingress): missing required field "enabled" in com.mirantis.boundless.v1alpha1.Blueprint.spec.components.core.ingress; if you choose to ignore these errors, turn validation off with --validate=false


5) Required check for all mandatory fields in helm chart info

addons:
      - name: example-server
        kind: chart
        enabled: true
        namespace: default
        chart:
      #    name: nginx
          repo: https://charts.bitnami.com/bitnami
          version: 15.1.1
          values: |
            "service":
              "type": "ClusterIP"

kubectl apply -f blueprint_manifest.yaml
error: error validating "blueprint_manifest.yaml": error validating data: ValidationError(Blueprint.spec.components.addons[0].chart): missing required field "name" in com.mirantis.boundless.v1alpha1.Blueprint.spec.components.addons.chart; if you choose to ignore these errors, turn validation off with --validate=false


addons:
      - name: example-server
        kind: chart
        enabled: true
        namespace: default
        chart:
          name: nginx
      #    repo: https://charts.bitnami.com/bitnami
          version: 15.1.1
          values: |
            "service":
              "type": "ClusterIP"

kubectl apply -f blueprint_manifest.yaml
`error: error validating "blueprint_manifest.yaml": error validating data: ValidationError(Blueprint.spec.components.addons[0].chart): missing required field "repo" in com.mirantis.boundless.v1alpha1.Blueprint.spec.components.addons.chart; if you choose to ignore these errors, turn validation off with --validate=false`

```
addons:
      - name: example-server
        kind: chart
        enabled: true
        namespace: default
        chart:
          name: nginx
          repo: https://charts.bitnami.com/bitnami
      #    version: 15.1.1
          values: |
            "service":
              "type": "ClusterIP"
```

kubectl apply -f blueprint_manifest.yaml
`error: error validating "blueprint_manifest.yaml": error validating data: ValidationError(Blueprint.spec.components.addons[0].chart): missing required field "version" in com.mirantis.boundless.v1alpha1.Blueprint.spec.components.addons.chart; if you choose to ignore these errors, turn validation off with --validate=false
`


6) Non-empty url is required for manifest

```
- name: nginx
        kind: Manifest
        enabled: true
        namespace: boundless-system
        manifest: 
          url: ""
```

kubectl apply -f blueprint_manifest.yaml
`The Blueprint "my-cluster" is invalid: spec.components.addons[0].manifest.url: Invalid value: "": spec.components.addons[0].manifest.url in body should be at least 1 chars long`









