### PR TITLE
[BOP-188] Update CI to use an enterprise token

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -16,4 +16,5 @@ jobs:
   push-to-ghcr:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }} # if all `needs` jobs are successful
     needs: [vet, test, e2e, build]
+    secrets: inherit
     uses: ./.github/workflows/push-to-ghcr.yml

--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -20,8 +20,8 @@ jobs:
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: MirantisContainers
+          password: ${{ secrets.PAT_CI_BOUNDLESS }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3
@@ -53,8 +53,8 @@ jobs:
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: MirantisContainers
+          password: ${{ secrets.PAT_CI_BOUNDLESS }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3
@@ -90,8 +90,8 @@ jobs:
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: MirantisContainers
+          password: ${{ secrets.PAT_CI_BOUNDLESS }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3
@@ -127,8 +127,8 @@ jobs:
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: MirantisContainers
+          password: ${{ secrets.PAT_CI_BOUNDLESS }}
 
       - name: Download artifact
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Updates the PAT to use the new one created for the `MirantisContainers` org

https://mirantis.jira.com/browse/BOP-188