### PR TITLE
[nojira] fix installation fails due to boundless-system not existing

### DIFF
--- a/controllers/blueprint_controller.go
+++ b/controllers/blueprint_controller.go
@@ -3,10 +3,8 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/mirantiscontainers/boundless-operator/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -123,7 +121,7 @@ func (r *BlueprintReconciler) deleteAddons(ctx context.Context, logger logr.Logg
 }
 
 func (r *BlueprintReconciler) createOrUpdateAddon(ctx context.Context, logger logr.Logger, addon *boundlessv1alpha1.Addon) error {
-	err := r.createNamespaceIfNotExist(ctx, logger, addon.Spec.Namespace)
+	err := utils.CreateNamespaceIfNotExist(r.Client, ctx, logger, addon.Spec.Namespace)
 	if err != nil {
 		return err
 	}
@@ -258,27 +256,6 @@ func addonResource(spec *boundlessv1alpha1.AddonSpec) *boundlessv1alpha1.Addon {
 	}
 
 	return addon
-}
-
-func (r *BlueprintReconciler) createNamespaceIfNotExist(ctx context.Context, logger logr.Logger, namespace string) error {
-	ns := corev1.Namespace{}
-	err := r.Get(ctx, client.ObjectKey{Name: namespace}, &ns)
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			logger.Info("namespace does not exist, creating", "Namespace", namespace)
-			ns.ObjectMeta.Name = namespace
-			err = r.Create(ctx, &ns)
-			if err != nil {
-				return err
-			}
-
-		} else {
-			logger.Info("error checking namespace exists", "Namespace", namespace)
-			return err
-		}
-	}
-
-	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/components/certmanager/certmanager.go
+++ b/pkg/components/certmanager/certmanager.go
@@ -51,6 +51,10 @@ func (c *certManager) Install(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	if err := utils.CreateNamespaceIfNotExist(c.client, ctx, c.logger, consts.NamespaceBoundlessSystem); err != nil {
+		return err
+	}
+	
 	applier := kubernetes.NewApplier(c.logger, c.client)
 	if err := applier.Apply(ctx, kubernetes.NewManifestReader([]byte(certManagerTemplate))); err != nil {
 		return err

--- a/pkg/components/helmcontroller/helmcontroller.go
+++ b/pkg/components/helmcontroller/helmcontroller.go
@@ -44,6 +44,10 @@ func (c *helmController) Install(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	if err := utils.CreateNamespaceIfNotExist(c.client, ctx, c.logger, consts.NamespaceBoundlessSystem); err != nil {
+		return err
+	}
+
 	applier := kubernetes.NewApplier(c.logger, c.client)
 	if err := applier.Apply(ctx, kubernetes.NewManifestReader([]byte(helmControllerTemplate))); err != nil {
 		return err

--- a/pkg/utils/namespace.go
+++ b/pkg/utils/namespace.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CreateNamespaceIfNotExist checks if provided namespace exists, and creates it if it does not exist.
+func CreateNamespaceIfNotExist(runtimeClient client.Client, ctx context.Context, logger logr.Logger, namespace string) error {
+	ns := corev1.Namespace{}
+	err := runtimeClient.Get(ctx, client.ObjectKey{Name: namespace}, &ns)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			logger.Info("namespace does not exist, creating", "Namespace", namespace)
+			ns.ObjectMeta.Name = namespace
+			err = runtimeClient.Create(ctx, &ns)
+			if err != nil {
+				return err
+			}
+
+		} else {
+			logger.Info("error checking namespace exists", "Namespace", namespace)
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Installation resource fails because `boundless-system` does not yet exist.

```
"error": "failed to apply 'ServiceAccount/helm-controller' resources in namespace 'boundless-system' from manifest at: failed to create resource \"helm-controller\" of GroupVersionKind=\"/v1, Kind=ServiceAccount\": namespaces \"boundless-system\" not found"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/Users/tpolkowski/Projects/boundless-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/Users/tpolkowski/Projects/boundless-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/Users/tpolkowski/Projects/boundless-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227
```


We should check and create it while creating installation resources.