### PR TITLE
[BOP-262] Add labels for all manifest objects

### DIFF
--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -18,6 +18,8 @@ const (
 
 	// defaultInterval interval for waiting for assertions
 	defaultInterval = time.Millisecond * 250
+
+	timeoutOneMinute = time.Minute * 1
 )
 
 func getObject(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object) func() bool {

--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -2,8 +2,6 @@ package controllers
 
 import (
 	"context"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -60,12 +58,12 @@ var _ = Describe("Testing installation controller", Ordered, Serial, func() {
 		It("Should delete Helm Controller", func() {
 			dep := &appsv1.Deployment{}
 			lookupKey := types.NamespacedName{Name: "helm-controller", Namespace: consts.NamespaceBoundlessSystem}
-			Eventually(getObject(context.TODO(), lookupKey, dep), 1*time.Minute, defaultInterval).Should(BeFalse())
+			Eventually(getObject(context.TODO(), lookupKey, dep), timeoutOneMinute, defaultInterval).Should(BeFalse())
 		})
 		It("Should delete cert manager", func() {
 			dep := &appsv1.Deployment{}
 			lookupKey := types.NamespacedName{Name: "cert-manager", Namespace: consts.NamespaceBoundlessSystem}
-			Eventually(getObject(context.TODO(), lookupKey, dep), 1*time.Minute, defaultInterval).Should(BeFalse())
+			Eventually(getObject(context.TODO(), lookupKey, dep), timeoutOneMinute, defaultInterval).Should(BeFalse())
 		})
 		AfterAll(func() {
 			// Create the Installation again to avoid the error in the next tests

--- a/pkg/components/certmanager/certmanager.go
+++ b/pkg/components/certmanager/certmanager.go
@@ -54,7 +54,7 @@ func (c *certManager) Install(ctx context.Context) error {
 	if err := utils.CreateNamespaceIfNotExist(c.client, ctx, c.logger, consts.NamespaceBoundlessSystem); err != nil {
 		return err
 	}
-	
+
 	applier := kubernetes.NewApplier(c.logger, c.client)
 	if err := applier.Apply(ctx, kubernetes.NewManifestReader([]byte(certManagerTemplate))); err != nil {
 		return err

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -27,8 +27,20 @@ func Render(logger logr.Logger, url string, values *boundlessv1alpha1.Values) ([
 	var resources []string
 	var images []kustypes.Image
 	var patches []kustypes.Patch
+	var labels []kustypes.Label
+
+	// This shall add the following label to all manifest objects
+	label := kustypes.Label{
+		Pairs: map[string]string{
+			"controlled-by": "boundless",
+		},
+		IncludeSelectors: true,
+	}
+
+	labels = append(labels, label)
 
 	resources = append(resources, url)
+
 	if values != nil {
 		if len(values.Images) > 0 {
 			for i := range values.Images {
@@ -66,6 +78,7 @@ func Render(logger logr.Logger, url string, values *boundlessv1alpha1.Values) ([
 	kus.Resources = resources
 	kus.Patches = patches
 	kus.Images = images
+	kus.Labels = labels
 
 	kd, err := yaml.Marshal(kus)
 	if err != nil {


### PR DESCRIPTION
### JIRA ticket:

https://mirantis.jira.com/browse/BOP-262

### Description
This PR adds label `controlled-by: boundless` for all manifest objects. I used Kustomize label transformer that adds labels to all resources.

### Testing

Create a metalLB addon.

```
 - name: ss-metallb
        kind: manifest
        enabled: true
        namespace: boundless-system
        manifest:
          url: "https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml"
          failurePolicy: "None"
          timeout: 45s

```

The objects that are created by the manifest addon should have the label `controlled-by: boundless`


```
boundless-operator % kubectl get addons -A
NAMESPACE          NAME         STATUS
boundless-system   ss-metallb   Available
```

kubectl get pods -n metallb-system
```
NAME                          READY   STATUS    RESTARTS   AGE
controller-568cc58d64-6b7b7   1/1     Running   0          36s
speaker-6qpc7                 1/1     Running   0          36s

```
**Describe metallb pods**

```
kubectl describe pod/controller-568cc58d64-6b7b7 -n metallb-system
Name:         controller-568cc58d64-6b7b7
Namespace:    metallb-system
Priority:     0
Node:         my-cluster-control-plane/172.19.0.3
Start Time:   Fri, 16 Feb 2024 11:09:34 -0500
Labels:       app=metallb
              component=controller
              controlled-by=boundless
              pod-template-hash=568cc58d64
```

**Describe CRDs**

```
kubectl describe crd addresspools.metallb.io
Name:         addresspools.metallb.io
Namespace:
Labels:       controlled-by=boundless
Annotations:  controller-gen.kubebuilder.io/version: v0.11.1
API Version:  apiextensions.k8s.io/v1
Kind:         CustomResourceDefinition
kubectl describe ns metallb-system
Name:         metallb-system
Labels:       controlled-by=boundless
              kubernetes.io/metadata.name=metallb-system
              pod-security.kubernetes.io/audit=privileged
              pod-security.kubernetes.io/enforce=privileged
              pod-security.kubernetes.io/warn=privileged
Annotations:  <none>
Status:       Active
```

**Describe namespace**

```
kubectl describe ns metallb-system
Name:         metallb-system
Labels:       controlled-by=boundless
              kubernetes.io/metadata.name=metallb-system
              pod-security.kubernetes.io/audit=privileged
              pod-security.kubernetes.io/enforce=privileged
              pod-security.kubernetes.io/warn=privileged
Annotations:  <none>
Status:       Active

```