### PR TITLE
[no jira] Add label prefix with mirantis domain

### DIFF
--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -7,7 +7,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"time"
 
 	operator "github.com/mirantiscontainers/boundless-operator/api/v1alpha1"
 	"github.com/mirantiscontainers/boundless-operator/pkg/consts"


### PR DESCRIPTION
### Description

This PR adds a label prefix with mirantis domain to all the objects created by manifest addon.
https://github.com/MirantisContainers/boundless-operator/pull/52#issuecomment-1949597978

### Testing

### Testing

Create a metalLB addon.

```
 - name: metallb
        kind: manifest
        enabled: true
        namespace: boundless-system
        manifest:
          url: "https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml"
          failurePolicy: "None"
          timeout: 45s

```

The objects that are created by the manifest addon should have the label `controlled-by: boundless`


```
boundless-operator % kubectl get addons -A
NAMESPACE          NAME         STATUS
boundless-system   metallb   Available
```

kubectl get pods -n metallb-system
```
NAME                          READY   STATUS    RESTARTS   AGE
controller-7bfc99bbd4-d5wvp   1/1     Running   0          27s
speaker-rrjs9                 1/1     Running   0          27s

```
**Describe metallb pods**

```
kubectl describe pod/controller-64c8478958-ltlz5 -n metallb-system
Name:         controller-64c8478958-ltlz5
Namespace:    metallb-system
Priority:     0
Node:         my-cluster-control-plane/172.19.0.2
Start Time:   Fri, 23 Feb 2024 17:12:06 -0500
Labels:       app=metallb
              com.mirantis.boundless/controlled-by=boundless
              component=controller
              pod-template-hash=64c8478958
```

**Describe CRDs**

```
kubectl describe crd addresspools.metallb.io
Name:         addresspools.metallb.io
Namespace:
Labels:       com.mirantis.boundless/controlled-by=boundless
Annotations:  controller-gen.kubebuilder.io/version: v0.11.1
API Version:  apiextensions.k8s.io/v1
Kind:         CustomResourceDefinition
Metadata:
```

**Describe namespace**

```
kubectl describe ns metallb-system
Name:         metallb-system
Labels:       com.mirantis.boundless/controlled-by=boundless
              kubernetes.io/metadata.name=metallb-system
              pod-security.kubernetes.io/audit=privileged
              pod-security.kubernetes.io/enforce=privileged
              pod-security.kubernetes.io/warn=privileged
Annotations:  <none>
Status:       Active


```