### PR TITLE
[BOP-740] Set helm repo type

### DIFF
--- a/pkg/controllers/helm/release.go
+++ b/pkg/controllers/helm/release.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -61,6 +62,11 @@ func (hc *Controller) CreateHelmRelease(ctx context.Context, addon *v1alpha1.Add
 	releaseName := addon.Spec.Name
 	chartSpec := addon.Spec.Chart
 
+	helmRepoType := sourcev1.HelmRepositoryTypeDefault
+	if strings.HasPrefix(chartSpec.Repo, "oci://") {
+		helmRepoType = sourcev1.HelmRepositoryTypeOCI
+	}
+
 	repo := &sourcev1.HelmRepository{
 		TypeMeta: helmRepositoryTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
@@ -68,7 +74,8 @@ func (hc *Controller) CreateHelmRelease(ctx context.Context, addon *v1alpha1.Add
 			Namespace: consts.NamespaceBoundlessSystem,
 		},
 		Spec: sourcev1.HelmRepositorySpec{
-			URL: chartSpec.Repo,
+			URL:  chartSpec.Repo,
+			Type: helmRepoType,
 			Interval: metav1.Duration{
 				Duration: helmRepoInterval,
 			},


### PR DESCRIPTION
# Description

MKE 4 Dashboard is deployed as helm chart stored in an OCI repository `ghcr.io`. BOP doesn't set the proper type when adding OCI repositories. This PR fixes this issue.

# Testing

I built an image with my change and deployed the BOP manifest with the modified image. Then, I deployed the helm chart with `oci://` repo and made sure it was created successfully 

Before the change
```
% k get HelmRepository -A | grep oci://
blueprint-system   repo-mke-dashboard-mke-dashboard        oci://ghcr.io/mirantiscontainers                     38m   False   invalid Helm repository URL: 'oci' URL scheme cannot be used with 'default' HelmRepository type
```

After the change
```
% k get HelmRepository -A | grep oci://
blueprint-system   repo-mke-dashboard-mke-dashboard        oci://ghcr.io/mirantiscontainers                     34m     
```

It looks like `oci` repos don't have good status, but there is no error anymore + the deployment appeared in the cluster. Before the change, no resources were created.