### PR TITLE
[BOP-690] Add tolerations in BOP operator and its components

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,12 +61,8 @@ spec:
         seccompProfile:
          type: RuntimeDefault
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - command:
         - /manager

--- a/deploy/static/blueprint-operator.yaml
+++ b/deploy/static/blueprint-operator.yaml
@@ -6301,9 +6301,5 @@ spec:
       serviceAccountName: blueprint-operator-controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
       - effect: NoSchedule
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
+        key: node-role.kubernetes.io/master

--- a/pkg/components/certmanager/template.go
+++ b/pkg/components/certmanager/template.go
@@ -5168,12 +5168,8 @@ spec:
       securityContext:
         runAsNonRoot: true
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: cert-manager
           image: "quay.io/jetstack/cert-manager-cainjector:v1.9.1"
@@ -5227,12 +5223,8 @@ spec:
       securityContext:
         runAsNonRoot: true
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: cert-manager
           image: "quay.io/jetstack/cert-manager-controller:v1.9.1"
@@ -5287,12 +5279,8 @@ spec:
       securityContext:
         runAsNonRoot: true
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: cert-manager
           image: "quay.io/jetstack/cert-manager-webhook:v1.9.1"

--- a/pkg/components/fluxcd/manifests/helm-controller.yaml
+++ b/pkg/components/fluxcd/manifests/helm-controller.yaml
@@ -28,12 +28,8 @@ spec:
         app: helm-controller
     spec:
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - args:
             - --events-addr=http://notification-controller.flux-system.svc.cluster.local./

--- a/pkg/components/fluxcd/manifests/kustomize-controller.yaml
+++ b/pkg/components/fluxcd/manifests/kustomize-controller.yaml
@@ -28,12 +28,8 @@ spec:
         app: kustomize-controller
     spec:
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - args:
             - --events-addr=http://notification-controller.flux-system.svc.cluster.local./

--- a/pkg/components/fluxcd/manifests/notification-controller.yaml
+++ b/pkg/components/fluxcd/manifests/notification-controller.yaml
@@ -64,12 +64,8 @@ spec:
         app: notification-controller
     spec:
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - args:
             - --watch-all-namespaces

--- a/pkg/components/fluxcd/manifests/source-controller.yaml
+++ b/pkg/components/fluxcd/manifests/source-controller.yaml
@@ -48,12 +48,8 @@ spec:
         app: source-controller
     spec:
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - args:
             - --events-addr=http://notification-controller.flux-system.svc.cluster.local./

--- a/pkg/components/webhook/template.go
+++ b/pkg/components/webhook/template.go
@@ -126,12 +126,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-      - effect: "NoSchedule"
-        operator: "Exists"
-      - effect: "NoExecute"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - command:
             - /manager


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-690

As per the discussion in [this](https://miracloud.slack.com/archives/C05Q9JN9M7C/p1718898955164499) thread, the only taint that is added to controller+worker node is `node-role.kubernetes.io/master:NoSchedule`. 

Here are the details from the manual testing. I have used changes from my [fork](https://github.com/sakshisharma84/blueprint-operator/tree/check-tol) to test these in MKE 4 cluster and changed https://github.com/MirantisContainers/mke/blob/main/cmd/apply.go#L57 to use the static manifest from my fork.
1) get taints

```
kubectl get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints
NAME               TAINTS
ip-172-31-34-246   [map[effect:NoSchedule key:node-role.kubernetes.io/master]]
ip-172-31-39-146   <none>
```

2) Deploy BOP using `mkectl apply -f mke.yaml `

```
kubectl get pods -n blueprint-system -o wide
NAME                                                    READY   STATUS    RESTARTS   AGE   IP             NODE               NOMINATED NODE   READINESS GATES
blueprint-operator-controller-manager-c5669fcc4-chgrp   2/2     Running   0          29s   10.244.110.1   ip-172-31-34-246   <none>           <none>
cert-manager-6578d9cd74-rxns4                           1/1     Running   0          20s   10.244.241.7   ip-172-31-39-146   <none>           <none>
cert-manager-cainjector-5586c79f7c-8bjkg                1/1     Running   0          20s   10.244.110.7   ip-172-31-34-246   <none>           <none>
cert-manager-webhook-5996dbd8f4-ptglp                   1/1     Running   0          20s   10.244.241.8   ip-172-31-39-146   <none>           <none>
```

```
kubectl get pods -n flux-system -o wide
NAME                                       READY   STATUS    RESTARTS   AGE   IP             NODE               NOMINATED NODE   READINESS GATES
helm-controller-5b9fc6b8d9-hnm8z           1/1     Running   0          36s   10.244.110.5   ip-172-31-34-246   <none>           <none>
kustomize-controller-695d44c46c-mb6f9      1/1     Running   0          36s   10.244.110.4   ip-172-31-34-246   <none>           <none>
notification-controller-66bc866999-5qb85   1/1     Running   0          35s   10.244.241.6   ip-172-31-39-146   <none>           <none>
source-controller-554684c49f-2w9zc         1/1     Running   0          35s   10.244.110.6   ip-172-31-34-246   <none>           <none>
```

```
kubectl describe deploy/blueprint-operator-controller-manager -n blueprint-system
Name:                   blueprint-operator-controller-manager
Namespace:              blueprint-system
CreationTimestamp:      Fri, 21 Jun 2024 10:55:43 -0400
Labels:                 app.kubernetes.io/component=manager
manager:
    Image:      ghcr.io/mirantis/boundless-operator:ss-toleration
    Port:       <none>
 Tolerations:     node-role.kubernetes.io/master:NoSchedule
Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
```



P.S. : K0s docs also do not have clear info about these taints. https://docs.k0sproject.io/head/worker-node-config/#taints


          