### PR TITLE
[NO JIRA] Fix for failing e2e uninstall test (metallb ) due to resource clean up

### DIFF
--- a/test/e2e/manifest_kustomize_test.go
+++ b/test/e2e/manifest_kustomize_test.go
@@ -60,6 +60,7 @@ func TestManifestKustomize(t *testing.T) {
 		)).
 		WithTeardown("Cleanup", funcs.AllOf(
 			ApplyCleanupBlueprint(),
+			funcs.DeleteResources(dir, "happypath/kustomize.yaml"),
 			funcs.ResourceDeletedWithin(2*time.Minute, newAddon(a1)),
 		)).
 		Feature()


### PR DESCRIPTION
CI e2e tests now fails almost consistently because metallb addon becomes unhealthy(debugging done https://github.com/MirantisContainers/blueprint-operator/actions/runs/9751605527/job/26913680985)

Some other similar failures:
https://github.com/MirantisContainers/blueprint-operator/actions/runs/9745294736/attempts/1
https://github.com/MirantisContainers/blueprint-operator/actions/runs/9745294736/attempts/2

From the investigation that I have done so far, sometimes, resource cleanup in [kustomize e2e test](https://github.com/MirantisContainers/blueprint-operator/blob/main/test/e2e/manifest_kustomize_test.go) takes more time than expected. And since e2e tests run serially, it causes the [next metallb test](https://github.com/MirantisContainers/blueprint-operator/blob/main/test/e2e/uninstall_addons_test.go) to fail.

This PR fixes it by cleaning up the resources.

P.S. This problem is reproducible in CI. The tests run fine when run locally with the same release tag.

```
E2E_TEST_FLAGS="-test.v -test.run ^TestUninstallAddons -img ghcr.io/mirantiscontainers/blueprint-operator:v1.0.8" make e2e
go test ./test/e2e/... -test.v -test.run ^TestUninstallAddons -img ghcr.io/mirantiscontainers/blueprint-operator:v1.0.8
?   	github.com/mirantiscontainers/boundless-operator/test/e2e/funcs	[no test files]
=== RUN   TestUninstallAddons
=== RUN   TestUninstallAddons/Uninstall_Addons
    feature.go:68: Applied resources from /Users/ssharma/blueprint-operator/test/e2e/manifests/addons/happypath/update.yaml (matched 1 manifests)
    feature.go:119: Waiting 2m0s for Blueprint.blueprint.mirantis.com blueprint-system/blueprint-cluster to exist...
    feature.go:128: 1 resources found to exist after 0.504s
    feature.go:213: current status of test-addon-1 is
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Available
    feature.go:202: component Addon blueprint-system/test-addon-1 have desired status type 'Available' after 4.006s
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Available
    feature.go:202: component Addon blueprint-system/test-addon-2 have desired status type 'Available' after 21.503s
    feature.go:213: current status of test-addon-3 is Available
    feature.go:202: component Addon blueprint-system/test-addon-3 have desired status type 'Available' after 0.504s
    feature.go:68: Applied resources from /Users/ssharma/blueprint-operator/test/e2e/manifests/addons/happypath/delete.yaml (matched 1 manifests)
    feature.go:119: Waiting 2m0s for Blueprint.blueprint.mirantis.com blueprint-system/blueprint-cluster to exist...
    feature.go:128: 1 resources found to exist after 0.503s
=== RUN   TestUninstallAddons/Uninstall_Addons/AllRemovedAddonsHaveBeenDeleted
    feature.go:181: Waiting 2m0s for Addon.blueprint.mirantis.com blueprint-system/test-addon-2 to be deleted...
    feature.go:189: resource Addon.blueprint.mirantis.com blueprint-system/test-addon-2 deleted after 0.505s
    feature.go:181: Waiting 2m0s for Addon.blueprint.mirantis.com blueprint-system/test-addon-3 to be deleted...
    feature.go:189: resource Addon.blueprint.mirantis.com blueprint-system/test-addon-3 deleted after 0.504s
=== RUN   TestUninstallAddons/Uninstall_Addons/Addon2ObjectsHasBeenDeleted
    feature.go:181: Waiting 2m0s for Deployment metallb-system/controller to be deleted...
    feature.go:189: resource Deployment metallb-system/controller deleted after 0.510s
=== RUN   TestUninstallAddons/Uninstall_Addons/Addon3ObjectsHasBeenDeleted
    feature.go:181: Waiting 2m0s for Deployment default/crossplane to be deleted...
    feature.go:189: resource Deployment default/crossplane deleted after 0.507s
=== RUN   TestUninstallAddons/Uninstall_Addons/Addon1StillAvailable
    feature.go:213: current status of test-addon-1 is Available
    feature.go:202: component Addon blueprint-system/test-addon-1 have desired status type 'Available' after 0.505s
    feature.go:297: Waiting 2m0s for deployment test-ns-1/test-addon-1-nginx to become Available...
    feature.go:303: Deployment test-ns-1/test-addon-1-nginx is Available after 0.508s
=== NAME  TestUninstallAddons/Uninstall_Addons
    feature.go:99: Deleted resource Addon.blueprint.mirantis.com blueprint-system/test-addon-1
    feature.go:181: Waiting 2m0s for Addon.blueprint.mirantis.com blueprint-system/test-addon-1 to be deleted...
    feature.go:189: resource Addon.blueprint.mirantis.com blueprint-system/test-addon-1 deleted after 0.503s
--- PASS: TestUninstallAddons (30.70s)
    --- PASS: TestUninstallAddons/Uninstall_Addons (30.70s)
        --- PASS: TestUninstallAddons/Uninstall_Addons/AllRemovedAddonsHaveBeenDeleted (1.01s)
        --- PASS: TestUninstallAddons/Uninstall_Addons/Addon2ObjectsHasBeenDeleted (0.51s)
        --- PASS: TestUninstallAddons/Uninstall_Addons/Addon3ObjectsHasBeenDeleted (0.51s)
        --- PASS: TestUninstallAddons/Uninstall_Addons/Addon1StillAvailable (1.01s)
PASS
ok  	github.com/mirantiscontainers/boundless-operator/test/e2e	104.896s
ssharma@Sakshi-Sharma-MacBook-Pro-14-inch-2021- blueprint-operator %
ssharma@Sakshi-Sharma-MacBook-Pro-14-inch-2021- blueprint-operator %
ssharma@Sakshi-Sharma-MacBook-Pro-14-inch-2021- blueprint-operator %
ssharma@Sakshi-Sharma-MacBook-Pro-14-inch-2021- blueprint-operator % E2E_TEST_FLAGS="-test.v -test.run ^TestUninstallAddons -img ghcr.io/mirantiscontainers/blueprint-operator:v1.0.8" make e2e
go test ./test/e2e/... -test.v -test.run ^TestUninstallAddons -img ghcr.io/mirantiscontainers/blueprint-operator:v1.0.8
?   	github.com/mirantiscontainers/boundless-operator/test/e2e/funcs	[no test files]
=== RUN   TestUninstallAddons
=== RUN   TestUninstallAddons/Uninstall_Addons
    feature.go:68: Applied resources from /Users/ssharma/blueprint-operator/test/e2e/manifests/addons/happypath/update.yaml (matched 1 manifests)
    feature.go:119: Waiting 2m0s for Blueprint.blueprint.mirantis.com blueprint-system/blueprint-cluster to exist...
    feature.go:128: 1 resources found to exist after 0.504s
    feature.go:213: current status of test-addon-1 is
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Progressing
    feature.go:213: current status of test-addon-1 is Available
    feature.go:202: component Addon blueprint-system/test-addon-1 have desired status type 'Available' after 4.004s
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Progressing
    feature.go:213: current status of test-addon-2 is Available
    feature.go:202: component Addon blueprint-system/test-addon-2 have desired status type 'Available' after 21.505s
    feature.go:213: current status of test-addon-3 is Available
    feature.go:202: component Addon blueprint-system/test-addon-3 have desired status type 'Available' after 0.503s
    feature.go:68: Applied resources from /Users/ssharma/blueprint-operator/test/e2e/manifests/addons/happypath/delete.yaml (matched 1 manifests)
    feature.go:119: Waiting 2m0s for Blueprint.blueprint.mirantis.com blueprint-system/blueprint-cluster to exist...
    feature.go:128: 1 resources found to exist after 0.503s
=== RUN   TestUninstallAddons/Uninstall_Addons/AllRemovedAddonsHaveBeenDeleted
    feature.go:181: Waiting 2m0s for Addon.blueprint.mirantis.com blueprint-system/test-addon-2 to be deleted...
    feature.go:189: resource Addon.blueprint.mirantis.com blueprint-system/test-addon-2 deleted after 0.504s
    feature.go:181: Waiting 2m0s for Addon.blueprint.mirantis.com blueprint-system/test-addon-3 to be deleted...
    feature.go:189: resource Addon.blueprint.mirantis.com blueprint-system/test-addon-3 deleted after 0.503s
=== RUN   TestUninstallAddons/Uninstall_Addons/Addon2ObjectsHasBeenDeleted
    feature.go:181: Waiting 2m0s for Deployment metallb-system/controller to be deleted...
    feature.go:189: resource Deployment metallb-system/controller deleted after 0.507s
=== RUN   TestUninstallAddons/Uninstall_Addons/Addon3ObjectsHasBeenDeleted
    feature.go:181: Waiting 2m0s for Deployment default/crossplane to be deleted...
    feature.go:189: resource Deployment default/crossplane deleted after 0.505s
=== RUN   TestUninstallAddons/Uninstall_Addons/Addon1StillAvailable
    feature.go:213: current status of test-addon-1 is Available
    feature.go:202: component Addon blueprint-system/test-addon-1 have desired status type 'Available' after 0.507s
    feature.go:297: Waiting 2m0s for deployment test-ns-1/test-addon-1-nginx to become Available...
    feature.go:303: Deployment test-ns-1/test-addon-1-nginx is Available after 0.511s
=== NAME  TestUninstallAddons/Uninstall_Addons
    feature.go:99: Deleted resource Addon.blueprint.mirantis.com blueprint-system/test-addon-1
    feature.go:181: Waiting 2m0s for Addon.blueprint.mirantis.com blueprint-system/test-addon-1 to be deleted...
    feature.go:189: resource Addon.blueprint.mirantis.com blueprint-system/test-addon-1 deleted after 0.504s
--- PASS: TestUninstallAddons (30.69s)
    --- PASS: TestUninstallAddons/Uninstall_Addons (30.69s)
        --- PASS: TestUninstallAddons/Uninstall_Addons/AllRemovedAddonsHaveBeenDeleted (1.01s)
        --- PASS: TestUninstallAddons/Uninstall_Addons/Addon2ObjectsHasBeenDeleted (0.51s)
        --- PASS: TestUninstallAddons/Uninstall_Addons/Addon3ObjectsHasBeenDeleted (0.51s)
        --- PASS: TestUninstallAddons/Uninstall_Addons/Addon1StillAvailable (1.02s)
PASS
ok  	github.com/mirantiscontainers/boundless-operator/test/e2e	93.784s
```

