### PR TITLE
[BOP-1488] Don't remove non-BOP resources

### DIFF
--- a/controllers/blueprint_controller.go
+++ b/controllers/blueprint_controller.go
@@ -20,7 +20,7 @@ import (
 )
 
 // managedByBOPSelector only selects objects with the label indicating that the object is managed by blueprint operator
-var managedByBOPSelector = utils.MustLabelSelector("app.kubernetes.io/managed-by", selection.Equals, []string{"blueprint-operator"})
+var managedByBOPSelector = utils.MustLabelSelector(consts.ManagedByLabel, selection.Equals, []string{consts.ManagedByValue})
 
 // BlueprintReconciler reconciles a Blueprint object
 type BlueprintReconciler struct {
@@ -245,7 +245,7 @@ func issuerObject(issuer blueprintv1alpha1.Issuer) client.Object {
 			Name:      issuer.Name,
 			Namespace: issuer.Namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "blueprint-operator",
+				consts.ManagedByLabel: consts.ManagedByValue,
 			},
 		},
 		Spec: issuer.Spec,
@@ -261,7 +261,7 @@ func clusterIssuerObject(issuer blueprintv1alpha1.ClusterIssuer) client.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: issuer.Name,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "blueprint-operator",
+				consts.ManagedByLabel: consts.ManagedByValue,
 			},
 		},
 		Spec: issuer.Spec,
@@ -278,7 +278,7 @@ func certificateObject(certificate blueprintv1alpha1.Certificate) client.Object 
 			Name:      certificate.Name,
 			Namespace: certificate.Namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "blueprint-operator",
+				consts.ManagedByLabel: consts.ManagedByValue,
 			},
 		},
 		Spec: certificate.Spec,

--- a/controllers/blueprint_controller_test.go
+++ b/controllers/blueprint_controller_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Object operations", func() {
 				&v1.Issuer{ObjectMeta: metav1.ObjectMeta{
 					Name:      "issuer1",
 					Namespace: "ns1",
-					Labels:    map[string]string{"app.kubernetes.io/managed-by": "blueprint-operator"},
+					Labels:    map[string]string{consts.ManagedByLabel: consts.ManagedByValue},
 				}},
 				&v1.Issuer{ObjectMeta: metav1.ObjectMeta{
 					Name:      "issuer2",
@@ -155,7 +155,7 @@ var _ = Describe("Object operations", func() {
 
 		It("creates issuer with BOP managed label", func(ctx context.Context) {
 			issuer := issuerObject(v1alpha1.Issuer{Name: "issuer1", Namespace: "ns1"})
-			Expect(issuer.GetLabels()["app.kubernetes.io/managed-by"]).To(Equal("blueprint-operator"))
+			Expect(issuer.GetLabels()[consts.ManagedByLabel]).To(Equal(consts.ManagedByValue))
 		})
 	})
 
@@ -164,7 +164,7 @@ var _ = Describe("Object operations", func() {
 			fakeClient := fake.NewClientBuilder().WithObjects(
 				&v1.ClusterIssuer{ObjectMeta: metav1.ObjectMeta{
 					Name:   "clusterissuer1",
-					Labels: map[string]string{"app.kubernetes.io/managed-by": "blueprint-operator"},
+					Labels: map[string]string{consts.ManagedByLabel: consts.ManagedByValue},
 				}},
 				&v1.ClusterIssuer{ObjectMeta: metav1.ObjectMeta{
 					Name:   "clusterissuer2",
@@ -181,7 +181,7 @@ var _ = Describe("Object operations", func() {
 
 		It("creates cluster issuer with BOP managed label", func(ctx context.Context) {
 			issuer := clusterIssuerObject(v1alpha1.ClusterIssuer{Name: "clusterissuer1"})
-			Expect(issuer.GetLabels()["app.kubernetes.io/managed-by"]).To(Equal("blueprint-operator"))
+			Expect(issuer.GetLabels()[consts.ManagedByLabel]).To(Equal(consts.ManagedByValue))
 		})
 	})
 
@@ -190,7 +190,7 @@ var _ = Describe("Object operations", func() {
 			fakeClient := fake.NewClientBuilder().WithObjects(
 				&v1.Certificate{ObjectMeta: metav1.ObjectMeta{
 					Name:   "certificate1",
-					Labels: map[string]string{"app.kubernetes.io/managed-by": "blueprint-operator"},
+					Labels: map[string]string{consts.ManagedByLabel: consts.ManagedByValue},
 				}},
 				&v1.Certificate{ObjectMeta: metav1.ObjectMeta{
 					Name:   "certificate2",
@@ -207,7 +207,7 @@ var _ = Describe("Object operations", func() {
 
 		It("creates certificate with BOP managed label", func(ctx context.Context) {
 			issuer := certificateObject(v1alpha1.Certificate{Name: "certificate1"})
-			Expect(issuer.GetLabels()["app.kubernetes.io/managed-by"]).To(Equal("blueprint-operator"))
+			Expect(issuer.GetLabels()[consts.ManagedByLabel]).To(Equal(consts.ManagedByValue))
 		})
 	})
 })

--- a/controllers/objects.go
+++ b/controllers/objects.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/mirantiscontainers/blueprint-operator/pkg/consts"
 	"github.com/mirantiscontainers/blueprint-operator/pkg/utils"
 )
 
@@ -51,7 +52,7 @@ func deleteObjects(ctx context.Context, logger logr.Logger, apiClient client.Cli
 		// the objects created by BOP (https://mirantis.jira.com/browse/BOP-919).
 		kind := o.GetObjectKind().GroupVersionKind().Kind
 		if slices.Contains([]string{"Certificate", "Issuer", "ClusterIssuer"}, kind) {
-			if o.GetLabels()["app.kubernetes.io/managed-by"] != "blueprint-operator" {
+			if o.GetLabels()[consts.ManagedByLabel] != consts.ManagedByValue {
 				logger.Info("Skipping deletion of ", "Kind", o.GetObjectKind().GroupVersionKind().Kind)
 				continue
 			}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -15,4 +15,10 @@ const (
 
 	// BlueprintContainerName is the name of the blueprint operator container
 	BlueprintContainerName = "manager"
+
+	// ManagedByLabel is the label used to identify resources managed by the blueprint operator
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+
+	// ManagedByValue is the label value used to identify resources managed by the blueprint operator
+	ManagedByValue = "blueprint-operator"
 )

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -11,7 +11,7 @@ import (
 func MustLabelSelector(key string, operator selection.Operator, values []string) client.MatchingLabelsSelector {
 	req, err := labels.NewRequirement(key, operator, values)
 	if err != nil {
-		panic("bad requirement: " + err.Error())
+		panic("panic creating label selector requirement: " + err.Error())
 	}
 
 	selector := labels.NewSelector().Add(*req)

--- a/test/e2e/install_certs_test.go
+++ b/test/e2e/install_certs_test.go
@@ -24,14 +24,14 @@ func TestInstallCerts(t *testing.T) {
 		Name:      "test-issuer-1",
 		Namespace: "test-issuer-ns-1",
 		Labels: map[string]string{
-			"app.kubernetes.io/managed-by": "blueprint-operator",
+			consts.ManagedByLabel: consts.ManagedByValue,
 		},
 	})
 	i2 := newIssuer(metav1.ObjectMeta{
 		Name:      "test-issuer-2",
 		Namespace: "test-issuer-ns-1",
 		Labels: map[string]string{
-			"app.kubernetes.io/managed-by": "blueprint-operator",
+			consts.ManagedByLabel: consts.ManagedByValue,
 		},
 	})
 
@@ -41,7 +41,7 @@ func TestInstallCerts(t *testing.T) {
 		Name:      "test-cert-1",
 		Namespace: "test-issuer-ns-1",
 		Labels: map[string]string{
-			"app.kubernetes.io/managed-by": "blueprint-operator",
+			consts.ManagedByLabel: consts.ManagedByValue,
 		},
 	})
 	cert1Specs := certmanager.CertificateSpec{
@@ -57,7 +57,7 @@ func TestInstallCerts(t *testing.T) {
 		Name:      "test-cert-2",
 		Namespace: "test-cert-ns-1",
 		Labels: map[string]string{
-			"app.kubernetes.io/managed-by": "blueprint-operator",
+			consts.ManagedByLabel: consts.ManagedByValue,
 		},
 	})
 	cert2Specs := certmanager.CertificateSpec{


### PR DESCRIPTION
Blueprint supports management of some cert-manager resources: Issuer, ClusterIssuer, and Certificate. All resources managed by BOP have a special label. However, in the case of ClusterIssuers, we didn't check for the label when removing resources, which resulted in mistakenly removing ClusterIssuers created outside of BOP. This PR fixes this issue by only listing objects with the `managed-by: blueprint-operator` label.

Integration tests were added for the listing and creation functions.

https://mirantis.jira.com/browse/BOP-1488
