### PR TITLE
[BOP-1279] Change module name

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,4 +1,4 @@
-module github.com/MirantisContainers/blueprint-operator/api
+module github.com/mirantiscontainers/blueprint-operator/api
 
 go 1.22.3
 

--- a/vendor/github.com/mirantiscontainers/blueprint-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/mirantiscontainers/blueprint-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -7,7 +7,7 @@ package v1alpha1
 import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 


### PR DESCRIPTION
Change module name from `MirantisContainers/blueprint-operator/api` to `mirantiscontainers/blueprint-operator/api` for consistency.

Follow up from https://github.com/MirantisContainers/blueprint-operator/pull/98