### PR TITLE
Use mirantis mirrored image for kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image:  ghcr.io/mirantiscontainers/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
`kube-rbac-proxy` has been deprecated and the repository hosting the image (`gcr.io/kubebuilder`) [will shutdown March 2025](https://github.com/kubernetes-sigs/kubebuilder/discussions/3907).

This PR switches to use image from `ghcr.io/mirantiscontainers/kubebuilder/kube-rbac-proxy` until we can implement the suggested workaround in this [discussion](https://github.com/kubernetes-sigs/kubebuilder/discussions/3907)