### PR TITLE
[BOP-1745] Configurable image registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,12 @@ e2e: ## Run e2e tests.
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -ldflags \
+    	"\
+    	-X main.commit=${COMMIT} \
+    	-X main.version=${VERSION} \
+    	-X main.date=${DATE} \
+        " -o manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -53,3 +53,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--image-registry=ghcr.io/mirantiscontainers"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,6 +68,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --image-registry=ghcr.io/mirantiscontainers
         image: ghcr.io/mirantiscontainers/blueprint-operator:latest
         name: manager
         securityContext:

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -1,4 +1,5 @@
-package utils
+// Package template provides utilities for parsing and Go templates.
+package template
 
 import (
 	"bytes"

--- a/main.go
+++ b/main.go
@@ -187,12 +187,9 @@ func main() {
 func printImages(imageRegistry string) {
 	for _, c := range controllers.AllComponents(nil, log.Log, imageRegistry) {
 		for _, image := range c.Images() {
+			// the println is used instead of logging for easier parsing
 			fmt.Println(image)
 		}
-	}
-
-	if version == "" {
-		version = "dev"
 	}
 
 	fmt.Printf("%s/blueprint-operator:%s\n", imageRegistry, version)

--- a/pkg/components/certmanager/certmanager.go
+++ b/pkg/components/certmanager/certmanager.go
@@ -25,9 +25,9 @@ const (
 
 	// images
 
-	caInjectorImage = "jetstack/cert-manager-cainjector:v1.9.1"
-	controllerImage = "jetstack/cert-manager-controller:v1.9.1"
-	webhookImage    = "jetstack/cert-manager-webhook:v1.9.1"
+	caInjectorImage = "jetstack/cert-manager-cainjector"
+	controllerImage = "jetstack/cert-manager-controller"
+	webhookImage    = "jetstack/cert-manager-webhook"
 )
 
 // certManager is a component that manages cert manager in the cluster.

--- a/pkg/components/certmanager/certmanager.go
+++ b/pkg/components/certmanager/certmanager.go
@@ -21,25 +21,73 @@ const (
 	deploymentCAInjector  = "cert-manager-cainjector"
 	deploymentCertManager = "cert-manager"
 	deploymentWebhook     = "cert-manager-webhook"
+
+	// images
+
+	caInjectorImage = "jetstack/cert-manager-cainjector:v1.9.1"
+	controllerImage = "jetstack/cert-manager-controller:v1.9.1"
+	webhookImage    = "jetstack/cert-manager-webhook:v1.9.1"
 )
 
 // certManager is a component that manages cert manager in the cluster.
 type certManager struct {
-	client client.Client
-	logger logr.Logger
+	client        client.Client
+	logger        logr.Logger
+	imageRegistry string
+}
+
+// imageConfig holds the images for the cert manager components
+type imageConfig struct {
+	CAInjectorImage string
+	ControllerImage string
+	WebhookImage    string
+}
+
+func newImageConfig(registry string) imageConfig {
+	if registry == "" {
+		registry = consts.MirantisImageRegistry
+	}
+
+	return imageConfig{
+		CAInjectorImage: fmt.Sprintf("%s/%s", registry, caInjectorImage),
+		ControllerImage: fmt.Sprintf("%s/%s", registry, controllerImage),
+		WebhookImage:    fmt.Sprintf("%s/%s", registry, webhookImage),
+	}
 }
 
 // NewCertManagerComponent creates a new instance of the cert manager component.
-func NewCertManagerComponent(client client.Client, logger logr.Logger) components.Component {
+func NewCertManagerComponent(client client.Client, logger logr.Logger, imageRegistry string) components.Component {
 	return &certManager{
-		client: client,
-		logger: logger,
+		client:        client,
+		logger:        logger,
+		imageRegistry: imageRegistry,
 	}
 }
 
 // Name returns the name of the component.
 func (c *certManager) Name() string {
 	return "cert-manager"
+}
+
+func (c *certManager) Images() []string {
+	images := newImageConfig(c.imageRegistry)
+
+	return []string{
+		images.CAInjectorImage,
+		images.ControllerImage,
+		images.WebhookImage,
+	}
+}
+
+func (c *certManager) renderManifest() ([]byte, error) {
+	images := newImageConfig(c.imageRegistry)
+
+	manifest, err := utils.ParseTemplate(certManagerTemplate, images)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse cert-manager manifest template: %w", err)
+	}
+
+	return manifest.Bytes(), nil
 }
 
 // Install installs cert manager in the cluster.
@@ -54,11 +102,16 @@ func (c *certManager) Install(ctx context.Context) error {
 	}
 
 	applier := kubernetes.NewApplier(c.logger, c.client)
-	if err := applier.Apply(ctx, kubernetes.NewManifestReader([]byte(certManagerTemplate))); err != nil {
+
+	certManagerManifest, err := c.renderManifest()
+	if err != nil {
+		return fmt.Errorf("unable to render cert-manager manifest: %w", err)
+	}
+	if err := applier.Apply(ctx, kubernetes.NewManifestReader(certManagerManifest)); err != nil {
 		return err
 	}
 
-	resources, err := kubernetes.NewManifestReader([]byte(certManagerTemplate)).ReadManifest()
+	resources, err := kubernetes.NewManifestReader(certManagerManifest).ReadManifest()
 	if err != nil {
 		return err
 	}
@@ -104,7 +157,13 @@ func (c *certManager) Uninstall(ctx context.Context) error {
 	defer cancel()
 
 	applier := kubernetes.NewApplier(c.logger, c.client)
-	reader := kubernetes.NewManifestReader([]byte(certManagerTemplate))
+
+	certManagerManifest, err := c.renderManifest()
+	if err != nil {
+		return fmt.Errorf("unable to render cert-manager manifest: %w", err)
+	}
+
+	reader := kubernetes.NewManifestReader(certManagerManifest)
 	objs, err := reader.ReadManifest()
 	if err != nil {
 		return err

--- a/pkg/components/certmanager/certmanager.go
+++ b/pkg/components/certmanager/certmanager.go
@@ -10,6 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/mirantiscontainers/blueprint-operator/internal/template"
 	"github.com/mirantiscontainers/blueprint-operator/pkg/components"
 	"github.com/mirantiscontainers/blueprint-operator/pkg/consts"
 	"github.com/mirantiscontainers/blueprint-operator/pkg/kubernetes"
@@ -23,6 +24,15 @@ const (
 	deploymentWebhook     = "cert-manager-webhook"
 
 	// images
+
+	// CAInjectorImageTag is the tag of the cert-manager cainjector image
+	CAInjectorImageTag = "v1.9.1"
+
+	// ControllerImageTag is the tag of the cert-manager controller image
+	ControllerImageTag = "v1.9.1"
+
+	// WebhookImageTag is the tag of the cert-manager webhook image
+	WebhookImageTag = "v1.9.1"
 
 	caInjectorImage = "jetstack/cert-manager-cainjector:v1.9.1"
 	controllerImage = "jetstack/cert-manager-controller:v1.9.1"
@@ -49,9 +59,9 @@ func newImageConfig(registry string) imageConfig {
 	}
 
 	return imageConfig{
-		CAInjectorImage: fmt.Sprintf("%s/%s", registry, caInjectorImage),
-		ControllerImage: fmt.Sprintf("%s/%s", registry, controllerImage),
-		WebhookImage:    fmt.Sprintf("%s/%s", registry, webhookImage),
+		CAInjectorImage: fmt.Sprintf("%s/%s:%s", registry, caInjectorImage, CAInjectorImageTag),
+		ControllerImage: fmt.Sprintf("%s/%s:%s", registry, controllerImage, ControllerImageTag),
+		WebhookImage:    fmt.Sprintf("%s/%s:%s", registry, webhookImage, WebhookImageTag),
 	}
 }
 
@@ -69,6 +79,7 @@ func (c *certManager) Name() string {
 	return "cert-manager"
 }
 
+// Images returns the images used by cert manager.
 func (c *certManager) Images() []string {
 	images := newImageConfig(c.imageRegistry)
 
@@ -82,7 +93,7 @@ func (c *certManager) Images() []string {
 func (c *certManager) renderManifest() ([]byte, error) {
 	images := newImageConfig(c.imageRegistry)
 
-	manifest, err := utils.ParseTemplate(certManagerTemplate, images)
+	manifest, err := template.ParseTemplate(certManagerTemplate, images)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse cert-manager manifest template: %w", err)
 	}

--- a/pkg/components/certmanager/certmanager.go
+++ b/pkg/components/certmanager/certmanager.go
@@ -25,15 +25,6 @@ const (
 
 	// images
 
-	// CAInjectorImageTag is the tag of the cert-manager cainjector image
-	CAInjectorImageTag = "v1.9.1"
-
-	// ControllerImageTag is the tag of the cert-manager controller image
-	ControllerImageTag = "v1.9.1"
-
-	// WebhookImageTag is the tag of the cert-manager webhook image
-	WebhookImageTag = "v1.9.1"
-
 	caInjectorImage = "jetstack/cert-manager-cainjector:v1.9.1"
 	controllerImage = "jetstack/cert-manager-controller:v1.9.1"
 	webhookImage    = "jetstack/cert-manager-webhook:v1.9.1"
@@ -59,9 +50,9 @@ func newImageConfig(registry string) imageConfig {
 	}
 
 	return imageConfig{
-		CAInjectorImage: fmt.Sprintf("%s/%s:%s", registry, caInjectorImage, CAInjectorImageTag),
-		ControllerImage: fmt.Sprintf("%s/%s:%s", registry, controllerImage, ControllerImageTag),
-		WebhookImage:    fmt.Sprintf("%s/%s:%s", registry, webhookImage, WebhookImageTag),
+		CAInjectorImage: fmt.Sprintf("%s/%s:%s", registry, caInjectorImage, consts.CertManagerCAInjectorImageTag),
+		ControllerImage: fmt.Sprintf("%s/%s:%s", registry, controllerImage, consts.CertManagerControllerImageTag),
+		WebhookImage:    fmt.Sprintf("%s/%s:%s", registry, webhookImage, consts.CertManagerWebhookImageTag),
 	}
 }
 

--- a/pkg/components/certmanager/template.go
+++ b/pkg/components/certmanager/template.go
@@ -5172,7 +5172,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.9.1"
+          image: {{ .CAInjectorImage }}
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -5227,7 +5227,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v1.9.1"
+          image: {{ .ControllerImage }}
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -5283,7 +5283,7 @@ spec:
         effect: NoSchedule
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-webhook:v1.9.1"
+          image: {{ .WebhookImage }}
           imagePullPolicy: IfNotPresent
           args:
           - --v=2

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -7,6 +7,9 @@ type Component interface {
 	// Name returns the name of the component
 	Name() string
 
+	// Images returns the images used by the component
+	Images() []string
+
 	// Install installs the component
 	Install(ctx context.Context) error
 

--- a/pkg/components/fluxcd/fluxcd.go
+++ b/pkg/components/fluxcd/fluxcd.go
@@ -32,6 +32,18 @@ const (
 
 	// images
 
+	// HelmControllerImageTag is the tag of the helm controller image
+	HelmControllerImageTag = "v1.0.1"
+
+	// KustomizeControllerImageTag is the tag of the kustomize controller image
+	KustomizeControllerImageTag = "v1.3.0"
+
+	// NotificationControllerImageTag is the tag of the notification controller image
+	NotificationControllerImageTag = "v1.3.0"
+
+	// SourceControllerImageTag is the tag of the source controller image
+	SourceControllerImageTag = "v1.3.0"
+
 	helmControllerImage         = "fluxcd/helm-controller:v1.0.1"
 	kustomizeControllerImage    = "fluxcd/kustomize-controller:v1.3.0"
 	notificationControllerImage = "fluxcd/notification-controller:v1.3.0"
@@ -58,10 +70,10 @@ func newImageConfig(registry string) imageConfig {
 	}
 
 	return imageConfig{
-		HelmControllerImage:         fmt.Sprintf("%s/%s", registry, helmControllerImage),
-		KustomizeControllerImage:    fmt.Sprintf("%s/%s", registry, kustomizeControllerImage),
-		NotificationControllerImage: fmt.Sprintf("%s/%s", registry, notificationControllerImage),
-		SourceControllerImage:       fmt.Sprintf("%s/%s", registry, sourceControllerImage),
+		HelmControllerImage:         fmt.Sprintf("%s/%s:%s", registry, helmControllerImage, HelmControllerImageTag),
+		KustomizeControllerImage:    fmt.Sprintf("%s/%s:%s", registry, kustomizeControllerImage, KustomizeControllerImageTag),
+		NotificationControllerImage: fmt.Sprintf("%s/%s:%s", registry, notificationControllerImage, NotificationControllerImageTag),
+		SourceControllerImage:       fmt.Sprintf("%s/%s:%s", registry, sourceControllerImage, SourceControllerImageTag),
 	}
 }
 
@@ -80,6 +92,7 @@ func (c *fluxcdComponent) Name() string {
 	return "fluxcd"
 }
 
+// Images returns the images used by fluxcd
 func (c *fluxcdComponent) Images() []string {
 	images := newImageConfig(c.imageRegistry)
 

--- a/pkg/components/fluxcd/fluxcd.go
+++ b/pkg/components/fluxcd/fluxcd.go
@@ -32,10 +32,10 @@ const (
 
 	// images
 
-	helmControllerImage         = "fluxcd/helm-controller:v1.0.1"
-	kustomizeControllerImage    = "fluxcd/kustomize-controller:v1.3.0"
-	notificationControllerImage = "fluxcd/notification-controller:v1.3.0"
-	sourceControllerImage       = "fluxcd/source-controller:v1.3.0"
+	helmControllerImage         = "fluxcd/helm-controller"
+	kustomizeControllerImage    = "fluxcd/kustomize-controller"
+	notificationControllerImage = "fluxcd/notification-controller"
+	sourceControllerImage       = "fluxcd/source-controller"
 )
 
 type fluxcdComponent struct {

--- a/pkg/components/fluxcd/fluxcd.go
+++ b/pkg/components/fluxcd/fluxcd.go
@@ -32,18 +32,6 @@ const (
 
 	// images
 
-	// HelmControllerImageTag is the tag of the helm controller image
-	HelmControllerImageTag = "v1.0.1"
-
-	// KustomizeControllerImageTag is the tag of the kustomize controller image
-	KustomizeControllerImageTag = "v1.3.0"
-
-	// NotificationControllerImageTag is the tag of the notification controller image
-	NotificationControllerImageTag = "v1.3.0"
-
-	// SourceControllerImageTag is the tag of the source controller image
-	SourceControllerImageTag = "v1.3.0"
-
 	helmControllerImage         = "fluxcd/helm-controller:v1.0.1"
 	kustomizeControllerImage    = "fluxcd/kustomize-controller:v1.3.0"
 	notificationControllerImage = "fluxcd/notification-controller:v1.3.0"
@@ -70,10 +58,10 @@ func newImageConfig(registry string) imageConfig {
 	}
 
 	return imageConfig{
-		HelmControllerImage:         fmt.Sprintf("%s/%s:%s", registry, helmControllerImage, HelmControllerImageTag),
-		KustomizeControllerImage:    fmt.Sprintf("%s/%s:%s", registry, kustomizeControllerImage, KustomizeControllerImageTag),
-		NotificationControllerImage: fmt.Sprintf("%s/%s:%s", registry, notificationControllerImage, NotificationControllerImageTag),
-		SourceControllerImage:       fmt.Sprintf("%s/%s:%s", registry, sourceControllerImage, SourceControllerImageTag),
+		HelmControllerImage:         fmt.Sprintf("%s/%s:%s", registry, helmControllerImage, consts.FluxCDHelmControllerImageTag),
+		KustomizeControllerImage:    fmt.Sprintf("%s/%s:%s", registry, kustomizeControllerImage, consts.FluxCDKustomizeControllerImageTag),
+		NotificationControllerImage: fmt.Sprintf("%s/%s:%s", registry, notificationControllerImage, consts.FluxCDNotificationControllerImageTag),
+		SourceControllerImage:       fmt.Sprintf("%s/%s:%s", registry, sourceControllerImage, consts.FluxCDSourceControllerImageTag),
 	}
 }
 

--- a/pkg/components/fluxcd/manifests/helm-controller.yaml
+++ b/pkg/components/fluxcd/manifests/helm-controller.yaml
@@ -52,7 +52,7 @@ spec:
                 resourceFieldRef:
                   containerName: manager
                   resource: limits.memory
-          image: fluxcd/helm-controller:v1.0.1
+          image: {{ .HelmControllerImage }}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/pkg/components/fluxcd/manifests/kustomize-controller.yaml
+++ b/pkg/components/fluxcd/manifests/kustomize-controller.yaml
@@ -52,7 +52,7 @@ spec:
                 resourceFieldRef:
                   containerName: manager
                   resource: limits.memory
-          image: fluxcd/kustomize-controller:v1.3.0
+          image: {{ .KustomizeControllerImage }}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/pkg/components/fluxcd/manifests/notification-controller.yaml
+++ b/pkg/components/fluxcd/manifests/notification-controller.yaml
@@ -87,7 +87,7 @@ spec:
                 resourceFieldRef:
                   containerName: manager
                   resource: limits.memory
-          image: fluxcd/notification-controller:v1.3.0
+          image: {{ .NotificationControllerImage }}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/pkg/components/fluxcd/manifests/source-controller.yaml
+++ b/pkg/components/fluxcd/manifests/source-controller.yaml
@@ -76,7 +76,7 @@ spec:
                 resourceFieldRef:
                   containerName: manager
                   resource: limits.memory
-          image: fluxcd/source-controller:v1.3.0
+          image: {{ .SourceControllerImage }}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/pkg/components/webhook/webhook.go
+++ b/pkg/components/webhook/webhook.go
@@ -10,6 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/mirantiscontainers/blueprint-operator/internal/template"
 	"github.com/mirantiscontainers/blueprint-operator/pkg/components"
 	"github.com/mirantiscontainers/blueprint-operator/pkg/consts"
 	"github.com/mirantiscontainers/blueprint-operator/pkg/kubernetes"
@@ -39,8 +40,9 @@ func NewWebhookComponent(client client.Client, logger logr.Logger) components.Co
 	}
 }
 
+// Images implements the components.Component interface, but returns an empty list
+// as the webhook uses the same image as the controller manager.
 func (c *webhook) Images() []string {
-	// webhook uses the same image as the controller manager, so no need to repeat it here
 	return []string{}
 }
 
@@ -78,7 +80,7 @@ func (c *webhook) Install(ctx context.Context) error {
 		Image: operatorImage,
 	}
 
-	rendered, err := utils.ParseTemplate(webhookTemplate, cfg)
+	rendered, err := template.ParseTemplate(webhookTemplate, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to render webhook template: %w", err)
 	}

--- a/pkg/components/webhook/webhook_test.go
+++ b/pkg/components/webhook/webhook_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mirantiscontainers/blueprint-operator/pkg/utils"
 )
 
 func Test_renderTemplate(t *testing.T) {
@@ -30,9 +32,9 @@ func Test_renderTemplate(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := renderTemplate(test.source, test.cfg)
+			got, err := utils.ParseTemplate(test.source, test.cfg)
 			assert.NoError(t, err)
-			assert.True(t, strings.Contains(string(got), test.cfg.Image), "Expected replacement not found in rendered template: %s", string(got))
+			assert.True(t, strings.Contains(got.String(), test.cfg.Image), "Expected replacement not found in rendered template: %s", got.String())
 		})
 	}
 }

--- a/pkg/components/webhook/webhook_test.go
+++ b/pkg/components/webhook/webhook_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/mirantiscontainers/blueprint-operator/pkg/utils"
+	"github.com/mirantiscontainers/blueprint-operator/internal/template"
 )
 
 func Test_renderTemplate(t *testing.T) {
@@ -32,7 +32,7 @@ func Test_renderTemplate(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := utils.ParseTemplate(test.source, test.cfg)
+			got, err := template.ParseTemplate(test.source, test.cfg)
 			assert.NoError(t, err)
 			assert.True(t, strings.Contains(got.String(), test.cfg.Image), "Expected replacement not found in rendered template: %s", got.String())
 		})

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -21,4 +21,7 @@ const (
 
 	// ManagedByValue is the label value used to identify resources managed by the blueprint operator
 	ManagedByValue = "blueprint-operator"
+
+	// MirantisImageRegistry is the default image registry for Mirantis images
+	MirantisImageRegistry = "ghcr.io/mirantiscontainers"
 )

--- a/pkg/consts/versions.go
+++ b/pkg/consts/versions.go
@@ -1,0 +1,24 @@
+package consts
+
+const (
+	// CertManagerCAInjectorImageTag is the tag of the cert-manager cainjector image
+	CertManagerCAInjectorImageTag = "v1.9.1"
+
+	// CertManagerControllerImageTag is the tag of the cert-manager controller image
+	CertManagerControllerImageTag = "v1.9.1"
+
+	// CertManagerWebhookImageTag is the tag of the cert-manager webhook image
+	CertManagerWebhookImageTag = "v1.9.1"
+
+	// FluxCDHelmControllerImageTag is the tag of the helm controller image
+	FluxCDHelmControllerImageTag = "v1.0.1"
+
+	// FluxCDKustomizeControllerImageTag is the tag of the kustomize controller image
+	FluxCDKustomizeControllerImageTag = "v1.3.0"
+
+	// FluxCDNotificationControllerImageTag is the tag of the notification controller image
+	FluxCDNotificationControllerImageTag = "v1.3.0"
+
+	// FluxCDSourceControllerImageTag is the tag of the source controller image
+	FluxCDSourceControllerImageTag = "v1.3.0"
+)

--- a/pkg/manifest/path.go
+++ b/pkg/manifest/path.go
@@ -5,7 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/mirantiscontainers/blueprint-operator/pkg/utils"
+	"github.com/mirantiscontainers/blueprint-operator/internal/template"
 )
 
 type reader func(fs.FS, string, interface{}) ([]*unstructured.Unstructured, error)
@@ -50,7 +50,7 @@ func ReadTemplate(rfs fs.FS, pathname string, cfg interface{}) ([]*unstructured.
 // parseTemplateFile parses a single file as a template using the provided config struct
 // and returns unstructured manifest objects.
 func parseTemplateFile(rfs fs.FS, pathname string, cfg interface{}) ([]*unstructured.Unstructured, error) {
-	buf, err := utils.ParseFSTemplate(rfs, pathname, cfg)
+	buf, err := template.ParseFSTemplate(rfs, pathname, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/template.go
+++ b/pkg/utils/template.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"path"
+)
+
+func executeTemplate(t *template.Template, cfg interface{}) (*bytes.Buffer, error) {
+	buf := &bytes.Buffer{}
+	err := t.Execute(buf, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to execute template: %s", err)
+	}
+
+	return buf, nil
+}
+
+// ParseTemplate receives an input template and a config struct and returns the
+// executed template.
+func ParseTemplate(sourceTmpl string, cfg interface{}) (*bytes.Buffer, error) {
+	tmpl, err := template.New("dummyTemplate").Parse(sourceTmpl)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse template: %s", err)
+	}
+
+	return executeTemplate(tmpl, cfg)
+}
+
+// ParseFSTemplate parses template from the supplied file system at the specified path
+// using the supplied config struct and returns the executed template.
+func ParseFSTemplate(sourceTmpl fs.FS, pathname string, cfg interface{}) (*bytes.Buffer, error) {
+	tmpl, err := template.New(path.Base(pathname)).ParseFS(sourceTmpl, pathname)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse template: %s", err)
+	}
+
+	return executeTemplate(tmpl, cfg)
+}


### PR DESCRIPTION
This PR makes image registry of BOP components configurable. Images used by fluxCD and cert-manager can be pulled from a different registry using the `--image-registry` flag of the controller manager CLI. 

Another new CLI flag `--print-images` allows users to print images used by the operator and exit.

For testing, I deployed BOP with these changes in my k0s cluster and printed all images

```
% kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec['initContainers', 'containers'][*].image}" |\
tr -s '[[:space:]]' '\n' |\
sort |\
uniq
docker.io/calico/apiserver:v3.28.2
docker.io/calico/cni:v3.28.2
docker.io/calico/csi:v3.28.2
docker.io/calico/kube-controllers:v3.28.2
docker.io/calico/node-driver-registrar:v3.28.2
docker.io/calico/node:v3.28.2
docker.io/calico/pod2daemon-flexvol:v3.28.2
docker.io/calico/typha:v3.28.2

// ------- BOP images --------
ghcr.io/mirantiscontainers/fluxcd/helm-controller:v1.0.1
ghcr.io/mirantiscontainers/fluxcd/kustomize-controller:v1.3.0
ghcr.io/mirantiscontainers/fluxcd/notification-controller:v1.3.0
ghcr.io/mirantiscontainers/fluxcd/source-controller:v1.3.0
ghcr.io/mirantiscontainers/jetstack/cert-manager-cainjector:v1.9.1
ghcr.io/mirantiscontainers/jetstack/cert-manager-controller:v1.9.1
ghcr.io/mirantiscontainers/jetstack/cert-manager-webhook:v1.9.1
ghcr.io/mirantiscontainers/kubebuilder/kube-rbac-proxy:v0.15.0
msr.ci.mirantis.com/dshishliannikov/blueprint-operator:latest
// ---------------------------

quay.io/k0sproject/coredns:1.11.3
quay.io/k0sproject/kube-proxy:v1.31.1
quay.io/k0sproject/pushgateway-ttl:1.4.0-k0s.0
quay.io/tigera/operator:v1.34.5
registry.k8s.io/metrics-server/metrics-server:v0.7.2
```

The blueprint operator image is pulled from my personal registry, which is expected in this testing scenario. All FluxCD and cert-manager images are pulled from `ghcr.io/mirantiscontainers`